### PR TITLE
[Create] Bullet 클래스 추가

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Bullet.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Bullet.java
@@ -1,0 +1,27 @@
+package com.shatteredpixel.shatteredpixeldungeon.items;
+
+import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
+
+public class Bullet extends Item {
+    {
+        image = ItemSpriteSheet.DEWDROP; // TODO: 이미지 변경
+        stackable = true;
+        bones = true;
+    }
+
+    @Override
+    public boolean isUpgradable() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdentified() {
+        return true;
+    }
+
+    @Override
+    public int value() {
+        return Math.max(1, quantity/10);
+    }
+
+}


### PR DESCRIPTION
Bullet 클래스를 추가했습니다.

- 여러 개 적재 가능
- 영웅의 유해에 등장 가능
- 업그레이드 불가능
- 항상 감정되어 있음
- 가격은 액체 금속의 1/5(즉, 개당 1/10골드)