### PR TITLE
[Fix] 재장전 및 텍스트 관련 오류 수정

### DIFF
--- a/core/src/main/assets/messages/items/items_ko.properties
+++ b/core/src/main/assets/messages/items/items_ko.properties
@@ -1491,7 +1491,7 @@ items.weapon.melee.wornshortsword.desc=오래 사용하여 낡아버린 소검�
 
 
 
-//총기 설명
+# 총기 설명
 items.weapon.melee.gun.stats_known=이 _%1$d단계_ 총기는 _%2$d-%3$d의 피해_를 입히며 _힘이 %4$d이상_이어야 제대로 다룰 수 있습니다.
 items.weapon.melee.gun.stats_unknown=보통 이 _%1$d단계_ 총기는 _%2$d-%3$d의 피해_를 입히며 _힘이 %4$d이상_이어야 제대로 다룰 수 있습니다.
 items.weapon.melee.gun.bullet_descs_known=이 총으로 발사하는 탄환은 _%1$d_-_%2$d_ 피해를 주며 _%3$d_/_%4$d_번 발사한 뒤에는 재장전해야 다시 발사가 가능합니다. 재장전에는 _%5$s_턴이 소모됩니다.
@@ -1508,19 +1508,21 @@ items.weapon.melee.gun.cursed_worn=이 총기는 저주받았기 때문에, 당�
 items.weapon.melee.gun.stats_desc=
 items.weapon.melee.gun.prompt=대상을 선택하세요
 items.weapon.melee.gun.remodeled=이 총기에는 %d이/가 장착되어 있습니다.
+items.weapon.melee.gun.need_to_equip=먼저 총기를 착용해야 합니다.
 
-//다이얼로그
+# 다이얼로그
 items.weapon.melee.gun.reload_success=당신은 총기에 %d발을 장전했다.
+items.weapon.melee.gun.reload_fail=장전할 총알이 없다.
 items.weapon.melee.gun.already_full_loaded=이미 모든 탄환이 장전되어 있다.
 items.weapon.melee.gun.fizzles=장전된 탄환이 없다.
 items.weapon.melee.gun.identify=당신은 현재 사용하고 있는 총기가 무엇인지 알 만큼 충분히 익숙해졌습니다.
 
-//1티어
-items.weapon.melee.crude_pistol.name=조잡한 권총
-items.weapon.melee.crude_pistol.stats=
-items.weapon.melee.crude_pistol.desc=양질의 재료를 사용해서 만든 것 같지는 않은 이 조잡한 권총은 아주 기본적인 발사 성능만을 가지고 있습니다.
+# 1티어
+items.weapon.melee.crudepistol.name=조잡한 권총
+items.weapon.melee.crudepistol.stats=
+items.weapon.melee.crudepistol.desc=양질의 재료를 사용해서 만든 것 같지는 않은 이 조잡한 권총은 아주 기본적인 발사 성능만을 가지고 있습니다.
 
-//2티어
+# 2티어
 items.weapon.melee.revolver.name=리볼버
 items.weapon.melee.revolver.stats=
 items.weapon.melee.revolver.desc=가운데 실린더에 여섯 개의 탄환을 넣어 돌아가면서 한 발씩 쏠 수 있는 이 권총은 한발 한발을 신중하게 조준하여 발사할 수 있습니다.
@@ -1529,41 +1531,41 @@ items.weapon.melee.handgun.name=자동권총
 items.weapon.melee.handgun.stats=이 총기는 매우 빠르게 발사할 수 있습니다.
 items.weapon.melee.handgun.desc=한 손으로 가볍게 들 수 있는 이 권총은 특유의 구조 덕에 발사 시 다음 탄환이 바로 약실에 들어가 빠르게 발사할 수 있습니다.
 
-//items.weapon.melee.blunderbuss.name=나팔총
-//items.weapon.melee.blunderbuss.stats=이 총기는 멀리 있는 적에게는 탄환의 정확성과 피해량이 크게 떨어집니다.\n\n이 총기는 가까이 있는 적에게 더 정확하며, 매우 큰 피해를 줄 수 있습니다.
-//items.weapon.melee.blunderbuss.desc=총구 끝이 나팔처럼 퍼져 있는 이 구식 산탄총은 여러 개의 탄환을 한 번에 넓게 발사합나디. 가까이 있는 적에게 발사해 탄환을 모두 적중시키면 매우 큰 피해를 입힐 수 있습니다.
+# items.weapon.melee.blunderbuss.name=나팔총
+# items.weapon.melee.blunderbuss.stats=이 총기는 멀리 있는 적에게는 탄환의 정확성과 피해량이 크게 떨어집니다.\n\n이 총기는 가까이 있는 적에게 더 정확하며, 매우 큰 피해를 줄 수 있습니다.
+# items.weapon.melee.blunderbuss.desc=총구 끝이 나팔처럼 퍼져 있는 이 구식 산탄총은 여러 개의 탄환을 한 번에 넓게 발사합나디. 가까이 있는 적에게 발사해 탄환을 모두 적중시키면 매우 큰 피해를 입힐 수 있습니다.
 
-//3티어
-items.weapon.melee.hunting_rifle.name=사냥용 소총
-items.weapon.melee.hunting_rifle.stats=
-items.weapon.melee.hunting_rifle.desc=멀리 뛰어 다니는 동물을 사냥하기 위해 만들어진 이 소총은 멀리 있는 적에게 효과적인 피해를 입힐 수 있습니다.
+# 3티어
+items.weapon.melee.huntingrifle.name=사냥용 소총
+items.weapon.melee.huntingrifle.stats=
+items.weapon.melee.huntingrifle.desc=멀리 뛰어 다니는 동물을 사냥하기 위해 만들어진 이 소총은 멀리 있는 적에게 효과적인 피해를 입힐 수 있습니다.
 
 items.weapon.melee.shotgun.name=산탄총
 items.weapon.melee.shotgun.stats=이 총기는 멀리 있는 적에게는 탄환의 정확성과 피해량이 크게 떨어집니다.\n\n이 총기는 가까이 있는 적에게 더 정확하며, 매우 큰 피해를 줄 수 있습니다.
 items.weapon.melee.shotgun.desc=한 번의 발사에 여러 개의 탄환을 발사하는 산탄총은 가까이 있는 적에게 모든 탄환을 적중시켜 매우 큰 피해를 줄 수 있지만, 대상이 멀리 있으면 정확성과 위력이 크게 감소합니다.
 
-items.weapon.melee.dual_pistol.name=쌍권총
-items.weapon.melee.dual_pistol.stats=이 총기는 매우 빠르게 발사할 수 있습니다.
-items.weapon.melee.dual_pistol.desc=양 손에 하나씩 들고 다닐 수 있는 이 작은 권총 2정은 각 총을 번갈아 발사해 다음 발사 준비까지의 공백을 줄여 궁극적으로 탄환을 빠르게 발사할 수 있게 됩니다.
+items.weapon.melee.dualpistol.name=쌍권총
+items.weapon.melee.dualpistol.stats=이 총기는 매우 빠르게 발사할 수 있습니다.
+items.weapon.melee.dualpistol.desc=양 손에 하나씩 들고 다닐 수 있는 이 작은 권총 2정은 각 총을 번갈아 발사해 다음 발사 준비까지의 공백을 줄여 궁극적으로 탄환을 빠르게 발사할 수 있게 됩니다.
 
-//items.weapon.melee.speargun.name=작살총
-//items.weapon.melee.speargun.stats=이 총기는 다트를 탄약으로 사용합니다.
-//items.weapon.melee.speargun.desc=날카로운 날붙이를 멀리 있는 동물에게 빠르게 발사하기 위해 제작된 이 총은 날붙이 대신 다트를 사용해 멀리 있는 적에게 큰 피해를 줄 수 있습니다.
+# items.weapon.melee.speargun.name=작살총
+# items.weapon.melee.speargun.stats=이 총기는 다트를 탄약으로 사용합니다.
+# items.weapon.melee.speargun.desc=날카로운 날붙이를 멀리 있는 동물에게 빠르게 발사하기 위해 제작된 이 총은 날붙이 대신 다트를 사용해 멀리 있는 적에게 큰 피해를 줄 수 있습니다.
 
-//4티어
-items.weapon.melee.assult_rifle.name=돌격 소총
-items.weapon.melee.assult_rifle.stats=
-items.weapon.melee.assult_rifle.desc=휴대성이 높은 자동소총으로, 많은 장탄수와 다소 큰 크기에도 불구하고 신속한 이동에 별다른 제약이 없는 것이 특징입니다.
+# 4티어
+items.weapon.melee.assultrifle.name=돌격 소총
+items.weapon.melee.assultrifle.stats=
+items.weapon.melee.assultrifle.desc=휴대성이 높은 자동소총으로, 많은 장탄수와 다소 큰 크기에도 불구하고 신속한 이동에 별다른 제약이 없는 것이 특징입니다.
 
-items.weapon.melee.sniper_rifle.name=저격 소총
-items.weapon.melee.sniper_rifle.stats=이 총기는 멀리 있는 적에게 더 강력합니다.\n\n이 총기는 가까이 있는 적에게는 정확성이 매우 떨어집니다.
-items.weapon.melee.sniper_rifle.desc=총열 위에 커다란 조준경이 달려 있는 저격 소총입니다. 총열이 길어 멀리 있는 적을 더욱 안정적이고 정확하게 조준할 수 있습니다.
+items.weapon.melee.sniperrifle.name=저격 소총
+items.weapon.melee.sniperrifle.stats=이 총기는 멀리 있는 적에게 더 강력합니다.\n\n이 총기는 가까이 있는 적에게는 정확성이 매우 떨어집니다.
+items.weapon.melee.sniperrifle.desc=총열 위에 커다란 조준경이 달려 있는 저격 소총입니다. 총열이 길어 멀리 있는 적을 더욱 안정적이고 정확하게 조준할 수 있습니다.
 
-//items.weapon.melee.submachinegun.name=기관단총
-//items.weapon.melee.submachinegun.stats=이 총기는 한 번에 5발의 탄환을 발사하지만, 정확성이 조금 떨어집니다.
-//items.weapon.melee.submachinegun.desc=이 작은 기관단총은 순식간에 많은 탄환을 쏟아붓지만, 짧은 시간에 많은 탄환을 발사하는 탓에 명중률이 조금 떨어집니다.
+# items.weapon.melee.submachinegun.name=기관단총
+# items.weapon.melee.submachinegun.stats=이 총기는 한 번에 5발의 탄환을 발사하지만, 정확성이 조금 떨어집니다.
+# items.weapon.melee.submachinegun.desc=이 작은 기관단총은 순식간에 많은 탄환을 쏟아붓지만, 짧은 시간에 많은 탄환을 발사하는 탓에 명중률이 조금 떨어집니다.
 
-//5티어
+# 5티어
 
 items.weapon.melee.magnum.name=대구경 권총
 items.weapon.melee.magnum.stats=
@@ -1577,18 +1579,19 @@ items.weapon.melee.rocketlauncher.name=로켓 발사기
 items.weapon.melee.rocketlauncher.stats=이 무기로 발사하는 탄환은 폭발하여 넓은 지역에 피해를 줄 수 있습니다.
 items.weapon.melee.rocketlauncher.desc=전차를 상대하기 위해 화약을 잔뜩 채워 넣은 로켓을 발사하는 이 무기는 매우 무거워 다루기가 힘들지만, 그만큼 화력은 매우 강력합니다.
 
-//items.weapon.melee.flamethrower.name=화염 방사기
-//items.weapon.melee.flamethrower.stats=이 화기는 액체 화염 물약 혹은 액체 금속을 탄약으로 사용합니다.\n\n이 화기로 발사하는 공격은 반드시 명중합니다.\n\n이 화기는 적에게 연속해서 발사하면 더 큰 피해를 줄 수 있습니다.
-//items.weapon.melee.flamethrower.desc=전방에 화염을 뿜어 여러 적에게 커다란 고통을 주기 위해 만들어진 이 화기는 가까운 적들에게 화염을 계속해서 뿜어 큰 피해를 주는 것이 가능하지만, 화염이 멀리까지 닿지 않아 멀리 있는 적에게는 피해를 입힐 수 없을 것입니다.
+# items.weapon.melee.flamethrower.name=화염 방사기
+# items.weapon.melee.flamethrower.stats=이 화기는 액체 화염 물약 혹은 액체 금속을 탄약으로 사용합니다.\n\n이 화기로 발사하는 공격은 반드시 명중합니다.\n\n이 화기는 적에게 연속해서 발사하면 더 큰 피해를 줄 수 있습니다.
+# items.weapon.melee.flamethrower.desc=전방에 화염을 뿜어 여러 적에게 커다란 고통을 주기 위해 만들어진 이 화기는 가까운 적들에게 화염을 계속해서 뿜어 큰 피해를 주는 것이 가능하지만, 화염이 멀리까지 닿지 않아 멀리 있는 적에게는 피해를 입힐 수 없을 것입니다.
 
-//items.weapon.melee.plasma_cannon.name=플라즈마 포
-//items.weapon.melee.plasma_cannon.stats=이 무기는 액체 금속을 탄약으로 사용합니다.\n\n이 무기는 다른 무기보다 느립니다.\n\n이 무기는 넓은 지역에 피해를 줍니다.\n\n이 무기는 자동으로 충전되며, 유물 충전의 효과를 받습니다.
-//items.weapon.melee.plasma_cannon.desc=상당히 높은 기술력으로 만들어져 마치 외계의 유물같은 이 무기는 거대한 플라즈마 덩어리를 발사해 넓은 지역에 있는 적에게 피해를 주고 마비시킬 것입니다. 발사 후 반동으로 인해 약간 뒤로 밀려날 것입니다.
+# items.weapon.melee.plasmacannon.name=플라즈마 포
+# items.weapon.melee.plasmacannon.stats=이 무기는 액체 금속을 탄약으로 사용합니다.\n\n이 무기는 다른 무기보다 느립니다.\n\n이 무기는 넓은 지역에 피해를 줍니다.\n\n이 무기는 자동으로 충전되며, 유물 충전의 효과를 받습니다.
+# items.weapon.melee.plasmacannon.desc=상당히 높은 기술력으로 만들어져 마치 외계의 유물같은 이 무기는 거대한 플라즈마 덩어리를 발사해 넓은 지역에 있는 적에게 피해를 주고 마비시킬 것입니다. 발사 후 반동으로 인해 약간 뒤로 밀려날 것입니다.
 
 items.armor.gunnerarmor.name=영웅의 전술 방탄복
 items.armor.gunnerarmor.desc=이 특별한 방탄복을 입은 거너는 다음 특수 능력을 사용할 수 있습니다.
 
-items.bullet.name=정체불명의 금속과 화약으로 만들어진 이 탄환은 총기에 장전하여 멀리 있는 적에게 효과적인 피해를 입힐 때 사용됩니다.
+items.bullet.name=총탄
+items.bullet.desc=정체불명의 금속과 화약으로 만들어진 이 탄환은 총기에 장전하여 멀리 있는 적에게 효과적인 피해를 입힐 때 사용됩니다.
 
 items.artifacts.gunsmithingbag.name=총기 개조 가방
 items.artifacts.gunsmithingbag.desc=거너가 자체적으로 개발한 이 금속 가방은 가지고 다니기 쉽도록 끈이 달려 있으며, 총기를 개조하거나 총탄을 제작하는 등 금속을 다루기 위한 도구들과 복잡한 기계들이 붙어 있습니다. 아래쪽에는 분해한 금속을 녹이기 위한 작은 용광로가 있으며, 가방에 필요한 금속을 추가하면 장비 분해 성능을 높일 수 있을 것 같습니다.

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/HeroClass.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/HeroClass.java
@@ -46,7 +46,6 @@ import com.shatteredpixel.shatteredpixeldungeon.items.armor.ClothArmor;
 import com.shatteredpixel.shatteredpixeldungeon.items.artifacts.CloakOfShadows;
 import com.shatteredpixel.shatteredpixeldungeon.items.bags.VelvetPouch;
 import com.shatteredpixel.shatteredpixeldungeon.items.food.Food;
-import com.shatteredpixel.shatteredpixeldungeon.items.Bullet;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.PotionOfHealing;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.PotionOfInvisibility;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.PotionOfLiquidFlame;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/AssultRifle.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/AssultRifle.java
@@ -8,7 +8,6 @@ public class AssultRifle extends Gun{
         image = ItemSpriteSheet.ASSULTRIFLE;
         tier = 4;
 
-        maxRounds = 12;
         timeToReload = 2f;
 
         // hitSound = ?
@@ -17,4 +16,8 @@ public class AssultRifle extends Gun{
 
     }
 
+    @Override
+    public int initialRounds() {
+        return 12;
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/CrudePistol.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/CrudePistol.java
@@ -11,9 +11,12 @@ public class CrudePistol extends Gun {
         // hitSoundPitch = ?
 
         tier = 1;
-        maxRounds = 4;
         bones = false; // 기본 무기는 영웅의 유해에 포함되지 않음
 
     }
 
+    @Override
+    public int initialRounds() {
+        return 4;
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/DualPistol.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/DualPistol.java
@@ -2,7 +2,7 @@ package com.shatteredpixel.shatteredpixeldungeon.items.weapon.melee;
 
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
 
-public class DualPistol extends Gun{
+public class DualPistol extends Gun {
 
     {
         image = ItemSpriteSheet.DUALPISTOL;
@@ -10,29 +10,38 @@ public class DualPistol extends Gun{
         // hitSound = ?
         // hitSoundPitch = ?
 
-        maxRounds = 12;
         timeToShoot = 0.5f;
         timeToReload = 2f;
         tier = 3;
         bones = true;
     }
 
+    @Override
     public int min(int lvl) {
         return 1 * (tier - 1) +    // base
                 lvl;               // level scaling
     }
 
+    @Override
     public int max(int lvl) {
         return 3 * (tier - 1) +    // base
                 lvl * (tier - 1);  // level scaling
     }
 
+    @Override
     public int shootMin(int lvl) {
         return 2 * (tier - 1) +     // base
                 lvl;                // level scaling
     }
 
+    @Override
     public int shootMax(int lvl) {
         return 5 * (tier - 1) +     // base
                 lvl * (tier - 1);   // level scaling
     }
+
+    @Override
+    public int initialRounds() {
+        return 4;
+    }
+}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/Gun.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/Gun.java
@@ -31,7 +31,7 @@ public abstract class Gun extends MeleeWeapon {
 
     public float timeToShoot = 1f;
     public float timeToReload = 1f;
-    public int maxRounds = 6;
+    public int maxRounds = initialRounds();
     public int curRounds = maxRounds;
 
     protected int collisionProperties = Ballistica.MAGIC_BOLT;
@@ -92,6 +92,10 @@ public abstract class Gun extends MeleeWeapon {
         return damage;
     }
 
+    public int initialRounds() {
+        return 6;
+    }
+
     @Override
     public String info() {
         String info = super.info();
@@ -99,7 +103,7 @@ public abstract class Gun extends MeleeWeapon {
         return info;
     }
 
-    public String statsInfo(){
+    public String statsInfo() {
         return Messages.get(this, "stats");
     }
 
@@ -116,7 +120,7 @@ public abstract class Gun extends MeleeWeapon {
     @Override
     public ArrayList<String> actions(Hero hero) {
         ArrayList<String> actions = super.actions(hero);
-        actions.add(AC_RELOAD);
+        if (isEquipped(hero)) actions.add(AC_RELOAD);
         actions.add(AC_SHOOT);
         return actions;
     }
@@ -141,6 +145,10 @@ public abstract class Gun extends MeleeWeapon {
             reloadBullet();
 
         } else if (action.equals(AC_SHOOT)) {
+            if (!isEquipped(hero)) {
+                GLog.i(Messages.get(Gun.class, "need_to_equip"));
+                return;
+            }
 
             if (cursed || hasCurseEnchant()) {
                 // TODO: 저주받았을 때 메커니즘 추가
@@ -223,14 +231,14 @@ public abstract class Gun extends MeleeWeapon {
         if (maxToUse == 0) {
             GLog.w(Messages.get(Gun.class, "already_full_loaded"));
             return;
+        } else if (bullet == null) {
+            GLog.w(Messages.get(Gun.class, "reload_fail"));
+            return;
         } else if (maxToUse < bullet.quantity()) {
             reload(maxToUse);
             bullet.quantity(bullet.quantity() - maxToUse);
             GLog.i(Messages.get(Gun.class, "reload_success", maxToUse));
             curUser.spendAndNext(timeToReload);
-        } else if (bullet.quantity() == 0) {
-            GLog.w(Messages.get(Gun.class, "reload_fail"));
-            return;
         } else {
             reload(bullet.quantity());
             GLog.i(Messages.get(Gun.class, "reload_success", bullet.quantity()));
@@ -263,6 +271,7 @@ public abstract class Gun extends MeleeWeapon {
 
                 if (target == curUser.pos || cell == curUser.pos) {
                     curGun.reloadBullet();
+                    return;
                 }
 
                 // curUser.sprite.zap(cell);

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/Handgun.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/Handgun.java
@@ -10,21 +10,26 @@ public class Handgun extends Gun{
         // hitSound = ?
         // hitSoundPitch = ?
 
-        maxRounds = 12;
         timeToShoot = 0.5f;
 
         tier = 2;
         bones = true;
     }
 
+    @Override
     public int shootMin(int lvl) {
         return (tier) +         // 2 base, down from 3
                 lvl;            // level scaling
     }
 
+    @Override
     public int shootMax(int lvl) {
         return 4 * (tier) +     // 8 base, down from 15
                 lvl * (tier);       // +2 per lvl, down from +3
     }
 
+    @Override
+    public int initialRounds() {
+        return 12;
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/HuntingRifle.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/HuntingRifle.java
@@ -18,22 +18,22 @@ public class HuntingRifle extends Gun {
 
     }
 
-    //@Override
-    //public void onShoot(Ballistica shot) {
-    //
-    //    Char ch = Actor.findChar(shot.collisionPos);
-    //    if (ch != null) {
-    //
-    //        float dmgBonus = (float) Math.min(Random.Int(shot.dist), 10 + buffedLvl());
-    //        curUser.shoot(ch, 1f, dmgBonus, 1.2f);
-    //        Sample.INSTANCE.play(Assets.Sounds.HIT_MAGIC, 1, Random.Float(0.87f, 1.15f));
-    //        // TODO: Hit Sound 변경
-    //
-    //        ch.sprite.burst(0xFFFFFFFF, buffedLvl() / 2 + 2);
-    //        // TODO: 스프라이트 변경
-    //
-    //    }
-    //
-    //}
+    @Override
+    public void onShoot(Ballistica shot) {
+
+        Char ch = Actor.findChar(shot.collisionPos);
+        if (ch != null) {
+
+            float dmgBonus = (float) Math.min(Random.Int(shot.dist), 10 + buffedLvl());
+            curUser.shoot(ch, 1f, dmgBonus, 1.2f);
+            Sample.INSTANCE.play(Assets.Sounds.HIT_MAGIC, 1, Random.Float(0.87f, 1.15f));
+            // TODO: Hit Sound 변경
+
+            ch.sprite.burst(0xFFFFFFFF, buffedLvl() / 2 + 2);
+            // TODO: 스프라이트 변경
+
+        }
+
+    }
 
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/MachineGun.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/MachineGun.java
@@ -7,7 +7,6 @@ public class MachineGun extends Gun {
     {
         image = ItemSpriteSheet.MACHINEGUN;
 
-        maxRounds = 40;
         timeToReload = 4;
         timeToShoot = 0.25f;
 
@@ -20,4 +19,8 @@ public class MachineGun extends Gun {
         ACC = 0.7f; //70% accuracy
     }
 
+    @Override
+    public int initialRounds() {
+        return 40;
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/MagnumPistol.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/MagnumPistol.java
@@ -8,7 +8,6 @@ public class MagnumPistol extends Gun{
         image = ItemSpriteSheet.MAGNUMPISTOL;
         tier = 5;
 
-        maxRounds = 8;
         timeToReload = 1f;
 
         // hitSound = ?
@@ -17,4 +16,8 @@ public class MagnumPistol extends Gun{
 
     }
 
+    @Override
+    public int initialRounds() {
+        return 8;
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/RocketLauncher.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/RocketLauncher.java
@@ -9,7 +9,6 @@ public class RocketLauncher extends Gun{
         image = ItemSpriteSheet.ASSULTRIFLE;
         tier = 4;
 
-        maxRounds = 1;
         timeToShoot = 2f;
         timeToReload = 3f;
 
@@ -29,4 +28,8 @@ public class RocketLauncher extends Gun{
                 lvl * (tier + 1);   // level scaling
     }
 
+    @Override
+    public int initialRounds() {
+        return 1;
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/ShotGun.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/ShotGun.java
@@ -14,7 +14,6 @@ public class ShotGun extends Gun {
 
     {
         image = ItemSpriteSheet.SHOTGUN;
-        maxRounds = 2;
         timeToReload = 2f;
 
         tier = 3;
@@ -53,4 +52,8 @@ public class ShotGun extends Gun {
 
     }
 
+    @Override
+    public int initialRounds() {
+        return 2;
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/SniperRifle.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/SniperRifle.java
@@ -13,7 +13,6 @@ public class SniperRifle extends Gun {
     {
         image = ItemSpriteSheet.SNIPERRIFLE;
 
-        maxRounds = 3;
         timeToReload = 2f;
 
         tier = 4;
@@ -38,4 +37,8 @@ public class SniperRifle extends Gun {
 
     }
 
+    @Override
+    public int initialRounds() {
+        return 3;
+    }
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/WornShortsword.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/WornShortsword.java
@@ -32,19 +32,7 @@ public class WornShortsword extends MeleeWeapon {
 		hitSoundPitch = 1.1f;
 
 		tier = 1;
-		ACC = 100f;
 
 		bones = false;
-	}
-	@Override
-	public int max(int lvl) {
-		return  800 +    //16 base, down from 20
-				lvl;   //scaling unchanged
-	}
-
-	@Override
-	public int min(int lvl) {
-		return  500 +    //16 base, down from 20
-				lvl;   //scaling unchanged
 	}
 }


### PR DESCRIPTION
* 텍스트 오류 수정
    - `.properties` 파일의 주석은 `//`가 아닌 `#`으로 시작하므로, 잘못된 부분 수정
    - 클래스 패스 수정(`gun`이 실제 경로에는 없지만 `.property` 파일에는 추가되어 있는 부분 삭제)
    - 총탄 name 및 desc 수정
    - 총기 착용 필요 텍스트 추가
* 사용하지 않는 클래스 import 구문 삭제
* 총알이 총 장탄수보다 많이 들어가는 오류 수정
    - maxRounds 메커니즘 변경
* Override 어노테이션 추가
* 총 미장착 시 발사 불가능하도록 수정
* 총 자신 클릭으로 재장전 시 동시에 발사되는 오류 수정
* 테스트 코드 삭제
    - 테스트 코드는 로컬에서만 사용하고, master 브랜치에 올리지 말 것
